### PR TITLE
Enhance support for LTX-2 video jobs and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,12 +22,18 @@ GRID_THREADS=1
 # Optional: Maximum image size in pixels (default: 1048576 = 1024x1024)
 GRID_MAX_PIXELS=1048576
 
-# Optional: Model to advertise to the grid (e.g. sdxl_turbo, stable_diffusion_1.5, sdxl)
+# Optional: Model to advertise to the grid (e.g. sdxl_turbo, stable_diffusion_1.5, sdxl, LTX-2)
 # This model will be used for all jobs regardless of what was requested
 GRID_MODEL=stable_diffusion
 
 # Optional: Specify a workflow file to use (can also be set with --workflow argument)
 WORKFLOW_FILE=turbovision.json
 
+# Optional: Workflow for video/LTX jobs (used when job is video or model is LTX-2)
+# WORKFLOW_FILE_VIDEO=ltx2_bridge_api.json
+
+# Optional: Worker type for grid registration: image (default) or video
+# GRID_WORKER_TYPE=image
+
 # Optional: Custom workflows directory (default: ./workflows)
-# WORKFLOW_DIR=/path/to/custom/workflow/directory 
+# WORKFLOW_DIR=/path/to/custom/workflow/directory

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Connect your local ComfyUI installation to the AI Power Grid network and run it 
 
 ## 🚀 Overview
 
-- **Bridge**: Receives image-generation jobs from AI Power Grid.  
+- **Bridge**: Receives image- and video-generation jobs from AI Power Grid.  
 - **Worker**: Executes jobs via your local ComfyUI instance.  
-- **Return**: Uploads generated images back to the network.  
+- **Return**: Uploads generated images or videos back to the network.  
 
-This allows you to contribute GPU cycles to a decentralized AI rendering network while leveraging your local ComfyUI setup.
+This allows you to contribute GPU cycles to a decentralized AI rendering network while leveraging your local ComfyUI setup. **LTX-2** (Lightricks text-to-video) is supported for video jobs.
 
 ---
 
@@ -70,6 +70,22 @@ WORKFLOW_FILE=my_workflow.json               # ComfyUI JSON export template
 
 * **`GRID_MODEL`** supports one or more model keys (comma-separated). If unset, the bridge auto-detects from your ComfyUI checkpoints.
 * **`WORKFLOW_FILE`** points to a JSON workflow in your `workflows/` directory.
+* **`WORKFLOW_FILE_VIDEO`** (optional) workflow for video/LTX jobs; used when the job requests video or model is LTX-2.
+* **`GRID_WORKER_TYPE`** (optional) set to `video` to register as a video worker; default `image`.
+
+### LTX-2 / Video workers
+
+To run as an **LTX-2** (text-to-video) worker:
+
+1. **ComfyUI** with [ComfyUI-LTXVideo](https://github.com/Lightricks/ComfyUI-LTXVideo) (or equivalent) and LTX-2 checkpoints (e.g. `ltx-2-19b-distilled-fp8.safetensors`) in `models/checkpoints/`.
+2. **Video Helper Suite** (VHS) or a workflow that outputs video (SaveVideo / VHS_VideoCombine) if you use the bundled LTX bridge workflow.
+3. Set in `.env`:
+   - `GRID_MODEL=LTX-2` (or `ltx-2`, `ltx`, `ltxv`)
+   - `WORKFLOW_FILE=ltx2_bridge_api.json` for the bundled LTX workflow with `_bridge` metadata, or use `WORKFLOW_FILE_VIDEO=ltx2_bridge_api.json` with a separate image workflow in `WORKFLOW_FILE`.
+   - `GRID_WORKER_TYPE=video` to advertise as a video worker (if the grid expects this).
+4. Workflows must be **API format** (ComfyUI: Dev Mode → Save as API Format). The bridge uses `workflows/ltx2_bridge_api.json` as a ready-made LTX-2 T2V workflow with video output.
+
+Video jobs return MP4 (or the format produced by your workflow) and are submitted with `media_type: video`. Resource use for LTX-2 is higher than image models; consider `GRID_THREADS=1` and sufficient GPU memory.
 
 ---
 

--- a/docs/PLAN_LTX_SUPPORT.md
+++ b/docs/PLAN_LTX_SUPPORT.md
@@ -1,0 +1,127 @@
+# Plan: Add LTX Support to the Bridge
+
+This document outlines the steps to add **LTX / LTX-2** (Lightricks text-to-video) support to the ComfyUI Bridge for AI Power Grid, so the bridge can accept video-generation jobs and run them via ComfyUI with LTX-2 workflows.
+
+---
+
+## 1. Current State
+
+- **Bridge**: Receives jobs from AI Power Grid, converts them to ComfyUI workflows, runs on local ComfyUI, returns images or videos.
+- **Job payload**: Already supports `media_type` (image/video), `source_processing` (txt2img, img2img, img2video), `payload.length` (frames), `payload.fps`; R2 upload and `_submit_result(..., media_type="video")` are implemented.
+- **Workflows**: `workflows/` contains several LTX-2 JSON files:
+  - **API format** (usable by bridge): `ltx2_text_to_video.json`, `ltx2_distilled.json`, `ltx2_i2v.json` (has SaveVideo).
+  - **Web UI format** (rejected by bridge): `ltx2.json`, `LTX-2_T2V_Distilled_wLora.json` — would need to be re-exported as API format if used.
+- **Legacy workflow updater**: Already has special handling for `LTXVScheduler`, `EmptyLTXVLatentVideo`, `RandomNoise`, and `SaveVideo` / `VHS_VideoCombine`.
+- **Gap**: No LTX-specific model mapping, no `_bridge` metadata on LTX workflows, worker is registered as image-only, and there is no clear path to “use LTX workflow when job is video or model is LTX”.
+
+---
+
+## 2. Goals
+
+1. **Advertise LTX/video capability** so the grid can send video (and optionally img2video) jobs to this worker.
+2. **Map grid model names** (e.g. `LTX-2`, `ltx`, `ltxv`) to the correct ComfyUI checkpoint / config.
+3. **Use an LTX workflow** when the job is for video or the requested model is LTX (workflow selection by model and/or media type).
+4. **Inject job parameters** into LTX workflows in a reliable way (prompt, negative, seed, dimensions, length, steps, cfg, source image for i2v) via `_bridge` metadata where possible.
+5. **Return video** from ComfyUI (SaveVideo / VHS_VideoCombine) and submit it correctly to the grid.
+
+---
+
+## 3. Implementation Plan
+
+### Phase 1: Model mapping and worker registration
+
+| Step | Description |
+|------|-------------|
+| 1.1 | **Model mapper** (`model_mapper.py`): Add LTX entries to `DEFAULT_MODEL_MAP` and extend `_build_model_map()` so that grid model names such as `LTX-2`, `ltx-2`, `ltx`, `ltxv`, `LTX-2 19B Distilled` map to the checkpoint filename used by your LTX workflows (e.g. `ltx-2-19b-distilled-fp8.safetensors`). |
+| 1.2 | **Auto-detect LTX checkpoints**: In `get_comfyui_models()` or `_build_model_map()`, detect checkpoints whose names contain `ltx` / `ltx-2` and register them as LTX models for the grid. |
+| 1.3 | **Worker registration** (`bridge.py`): If the grid API supports a video worker type or a list of types, add support for advertising video (e.g. `worker_type: "video"` or a second registration for video). If the API only supports a single type, document that users can run a second bridge instance with an LTX workflow and video model. Keep current image registration unchanged when not advertising LTX. |
+| 1.4 | **Config**: Document (e.g. in README and `.env.example`) how to advertise an LTX model: e.g. `GRID_MODEL=LTX-2` or `ltx-2-19b-distilled`, and optionally `WORKFLOW_FILE=ltx2_distilled.json` or a new bridge-ready LTX workflow. |
+
+### Phase 2: Workflow selection and LTX-specific workflow
+
+| Step | Description |
+|------|-------------|
+| 2.1 | **Workflow selection**: When `WORKFLOW_FILE` is set, keep current behavior (single workflow for all jobs). Optionally add logic so that when the job’s `media_type` is `video` or the job’s `model` maps to an LTX checkpoint, the bridge can use a dedicated LTX workflow (e.g. from `WORKFLOW_FILE_VIDEO` or `WORKFLOW_FILE_LTX` env var, or a convention like `workflows/ltx2_bridge_api.json`). |
+| 2.2 | **Create or choose an API-format LTX workflow** that: (a) outputs **video** (SaveVideo or VHS_VideoCombine), (b) is in API format (dict keyed by node id, no top-level `nodes` array), (c) uses a single checkpoint so the bridge can override only what’s needed. Prefer starting from `ltx2_distilled.json` or `ltx2_text_to_video.json` and adding a SaveVideo node, or from `ltx2_i2v.json` for img2video. |
+| 2.3 | **Add `_bridge` metadata** to that workflow (see Section 4) so the bridge can inject prompt, negative (if supported), seed, steps, cfg, width, height, length, and optionally source_image, without relying on legacy node scanning. |
+
+### Phase 3: Bridge workflow update logic for LTX
+
+| Step | Description |
+|------|-------------|
+| 3.1 | **_update_workflow_with_metadata**: Ensure `_bridge` supports a `video_latent` node and a `conditioning` (or prompt) node that matches LTX (e.g. CLIPTextEncode feeding into LTXVConditioning, or the node that feeds positive/negative into LTXVConditioning). Already partially present; extend if LTX uses different node IDs or field names. |
+| 3.2 | **LTX-specific fields**: In the chosen LTX workflow, map `_bridge.fields` (and nodes) for: prompt (and negative if applicable), seed, steps, cfg, width, height, length. For img2video, map `source_image` to the LoadImage (or preprocess) node. |
+| 3.3 | **Legacy path**: If an LTX workflow is used without `_bridge`, the legacy updater already handles `EmptyLTXVLatentVideo`, `LTXVScheduler`, `SaveVideo`/`VHS_VideoCombine`. Add or verify handling for **LTXVConditioning** (e.g. do not overwrite its inputs if the prompt is applied upstream; or identify the CLIPTextEncode nodes that feed it and update those). |
+| 3.4 | **Output filename**: Ensure the output node (SaveVideo / VHS_VideoCombine) gets `filename_prefix` like `video/aipg_{job_id}` or `aipg_{job.id}` so results are identifiable and `_get_generated_media` can find the video. |
+
+### Phase 4: End-to-end and docs
+
+| Step | Description |
+|------|-------------|
+| 4.1 | **Test**: Run the bridge with `WORKFLOW_FILE=<ltx_bridge_workflow>.json` and `GRID_MODEL=LTX-2` (or equivalent), and verify: job received, workflow submitted, ComfyUI produces video, bridge downloads it and submits with `media_type=video` and correct R2/content-type. |
+| 4.2 | **Docs**: Update README with an “LTX-2 / Video” section: required ComfyUI nodes (ComfyUI-LTXVideo or equivalent), model paths, env vars (`GRID_MODEL`, `WORKFLOW_FILE`), and that video jobs return MP4 (or the actual format) via R2 or base64. |
+| 4.3 | **Optional**: Add a small table in README mapping grid model names to suggested workflow files (e.g. `LTX-2` → `ltx2_bridge_api.json`). |
+
+---
+
+## 4. Suggested `_bridge` metadata for an LTX workflow
+
+Example structure for a text-to-video LTX workflow (adjust node IDs to match the real workflow):
+
+```json
+"_bridge": {
+  "version": 1,
+  "name": "LTX-2 T2V",
+  "media_type": "video",
+  "supports_negative": true,
+  "nodes": {
+    "prompt": "3",
+    "negative_prompt": "4",
+    "sampler": "7",
+    "latent": null,
+    "video_latent": "6",
+    "output": "9",
+    "source_image": "98"
+  },
+  "fields": {
+    "prompt": "text",
+    "negative_prompt": "text",
+    "seed": "seed",
+    "width": "width",
+    "height": "height",
+    "steps": "steps",
+    "cfg": "cfg",
+    "length": "length"
+  }
+}
+```
+
+- For **ltx2_distilled.json**-style flows: prompt/negative may feed into **LTXVConditioning**; then the node IDs in `nodes` should point to the CLIPTextEncode (or equivalent) nodes that feed into LTXVConditioning, and `sampler` to the KSampler, `video_latent` to `EmptyLTXVLatentVideo`, `output` to SaveVideo (if you add it) or the node that produces the final video.
+- If the workflow uses **SaveImage** for frames only: either add a SaveVideo (or VHS) node and point `output` to it, or document that this workflow is frame-only and the bridge would need to assemble frames into video (out of scope for initial LTX support; prefer workflows that output video directly).
+
+---
+
+## 5. File checklist
+
+| File | Action |
+|------|--------|
+| `model_mapper.py` | Add LTX model names and optional LTX checkpoint detection. |
+| `bridge.py` | Optional: video worker registration; workflow selection by media_type/model; ensure _bridge and legacy paths handle LTX prompt/conditioning/video_latent/output. |
+| `workflows/` | Add one API-format LTX workflow with SaveVideo (or VHS) and `_bridge` metadata (e.g. `ltx2_bridge_api.json` or extend `ltx2_distilled.json`). |
+| `README.md` | Document LTX/video setup, env vars, and model/workflow mapping. |
+| `.env.example` | Add `WORKFLOW_FILE_VIDEO` or `WORKFLOW_FILE_LTX` and example `GRID_MODEL=LTX-2` if implemented. |
+
+---
+
+## 6. Risks and notes
+
+- **Grid API**: Confirm whether the grid expects `worker_type: "video"` (or similar) for video jobs and whether pop/submit payloads differ for video (e.g. `media_type`, R2, content-type). The bridge already sends `media_type: "video"` on submit; registration side may need to match.
+- **ComfyUI-LTXVideo**: LTX workflows depend on ComfyUI-LTXVideo (or equivalent) custom nodes. Document this clearly so users install the right stack.
+- **Resource usage**: Video jobs are heavier than image jobs; consider documenting recommended `GRID_THREADS` and GPU memory for LTX-2.
+- **Web UI vs API workflows**: `ltx2.json` and `LTX-2_T2V_Distilled_wLora.json` are Web UI format; the bridge requires API format. Either export them from ComfyUI as “API format” or maintain a separate, minimal API-format LTX workflow for the bridge.
+
+---
+
+## 7. Summary
+
+Adding LTX support requires: (1) mapping grid model names to LTX checkpoints and optionally advertising video workers, (2) selecting an API-format LTX workflow that outputs video and adding `_bridge` metadata, (3) ensuring the bridge’s metadata and legacy updaters correctly set prompt, seed, dimensions, length, and source image for LTX nodes, and (4) documenting setup and optional env vars. The existing code already handles video output and submission; the main work is model mapping, workflow selection, a single bridge-ready LTX workflow with `_bridge`, and registration/docs.

--- a/model_mapper.py
+++ b/model_mapper.py
@@ -65,7 +65,13 @@ class ModelMapper:
         "juggernaut_xl": "juggernaut_xl.safetensors",
         "playground_v2": "playground_v2.safetensors",
         "dreamshaper_8": "dreamshaper_8.safetensors",
-        "stable_diffusion": "v1-5-pruned-emaonly.safetensors"
+        "stable_diffusion": "v1-5-pruned-emaonly.safetensors",
+        # LTX-2 (Lightricks text-to-video)
+        "LTX-2": "ltx-2-19b-distilled-fp8.safetensors",
+        "ltx-2": "ltx-2-19b-distilled-fp8.safetensors",
+        "ltx": "ltx-2-19b-distilled-fp8.safetensors",
+        "ltxv": "ltx-2-19b-distilled-fp8.safetensors",
+        "ltx2": "ltx-2-19b-distilled-fp8.safetensors",
     }
     
     def __init__(self):
@@ -121,6 +127,14 @@ class ModelMapper:
             elif "v2-1" in lower_filename or "v2.1" in lower_filename or "sd2.1" in lower_filename:
                 self.model_map["stable_diffusion_2.1"] = model_filename
             
+            # LTX-2 / Lightricks video checkpoints
+            elif "ltx-2" in lower_filename or "ltx_2" in lower_filename or ("ltx" in lower_filename and "19b" in lower_filename):
+                self.model_map["LTX-2"] = model_filename
+                self.model_map["ltx-2"] = model_filename
+                self.model_map["ltx"] = model_filename
+                self.model_map["ltxv"] = model_filename
+                self.model_map["ltx2"] = model_filename
+            
             # Map specific model names
             model_name_map = {
                 "juggernaut": "juggernaut_xl",
@@ -156,9 +170,19 @@ class ModelMapper:
             if horde_model_name.lower() in horde_name.lower() or horde_name.lower() in horde_model_name.lower():
                 return local_name
         
+        # Fallback to DEFAULT_MODEL_MAP when mapper not initialized or no match (e.g. LTX-2)
+        normalized = horde_model_name.strip().lower()
+        for grid_name, local_name in self.DEFAULT_MODEL_MAP.items():
+            if grid_name.lower() == normalized or normalized in grid_name.lower():
+                return local_name
+        
         # Fall back to the default model
-        print(f"Warning: No mapping found for model '{horde_model_name}', using default: {self.default_model}")
-        return self.default_model
+        if self.default_model:
+            print(f"Warning: No mapping found for model '{horde_model_name}', using default: {self.default_model}")
+            return self.default_model
+        fallback = self.DEFAULT_MODEL_MAP.get("stable_diffusion", "v1-5-pruned-emaonly.safetensors")
+        print(f"Warning: No mapping found for model '{horde_model_name}', using fallback: {fallback}")
+        return fallback
     
     def get_available_horde_models(self) -> List[str]:
         """Get a list of AI Power Grid model names that can be supported.
@@ -172,15 +196,19 @@ class ModelMapper:
         # Add default models if we have appropriate local models
         sdxl_keywords = ["xl", "sdxl"]
         sd15_keywords = ["1.5", "v1-5"]
+        ltx_keywords = ["ltx-2", "ltx_2", "ltx"]
         
         has_sdxl = any(any(kw in m.lower() for kw in sdxl_keywords) for m in self.available_models)
         has_sd15 = any(any(kw in m.lower() for kw in sd15_keywords) for m in self.available_models)
+        has_ltx = any(any(kw in m.lower() for kw in ltx_keywords) for m in self.available_models)
         
         standard_models = []
         if has_sdxl and "sdxl" not in result:
             standard_models.append("sdxl")
         if has_sd15 and "stable_diffusion_1.5" not in result:
             standard_models.append("stable_diffusion_1.5")
+        if has_ltx and "LTX-2" not in result:
+            standard_models.append("LTX-2")
             
         # Combine and remove duplicates
         result.extend(standard_models)

--- a/start_bridge.py
+++ b/start_bridge.py
@@ -57,7 +57,9 @@ async def main():
     # Parse command line arguments
     parser = argparse.ArgumentParser(description='Start ComfyUI bridge')
     parser.add_argument('--workflow', '-w', help='Workflow JSON file to use from workflows directory')
+    parser.add_argument('--workflow-video', help='Workflow for video/LTX jobs (overrides WORKFLOW_FILE_VIDEO in .env)')
     parser.add_argument('--grid-model', help='Model to advertise to the grid (overrides GRID_MODEL in .env)')
+    parser.add_argument('--worker-type', choices=('image', 'video'), help='Worker type for grid (default: image)')
     args = parser.parse_args()
     
     # Load environment variables from .env file
@@ -75,9 +77,11 @@ async def main():
     
     # Use command line argument for workflow file if provided, otherwise use environment variable
     workflow_file = args.workflow or os.environ.get("WORKFLOW_FILE")
+    workflow_file_video = args.workflow_video or os.environ.get("WORKFLOW_FILE_VIDEO")
     
     # Use command line argument for grid model if provided, otherwise use environment variable
     grid_model = args.grid_model or os.environ.get("GRID_MODEL")
+    worker_type = args.worker_type or os.environ.get("GRID_WORKER_TYPE", "image")
     
     if not api_key:
         print("Error: GRID_API_KEY environment variable is required")
@@ -113,7 +117,9 @@ async def main():
             max_pixels=max_pixels,
             workflow_dir=workflow_dir,
             workflow_file=workflow_file,
-            grid_model=grid_model
+            grid_model=grid_model,
+            workflow_file_video=workflow_file_video,
+            worker_type=worker_type
         )
         
         # Start the bridge

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -38,6 +38,7 @@ The repository includes several pre-made templates:
 - `sdxl_turbo_workflow.json` - For SDXL Turbo (optimized parameters)
 - `turbovision.json` - For TurboVision XL
 - `sdxl-lightning.json` - For SDXL Lightning
+- **`ltx2_bridge_api.json`** - LTX-2 text-to-video (Lightricks). Uses `_bridge` metadata; requires ComfyUI-LTXVideo and optionally VHS for video output. Set `GRID_MODEL=LTX-2` and `WORKFLOW_FILE=ltx2_bridge_api.json` (or `WORKFLOW_FILE_VIDEO=ltx2_bridge_api.json`).
 
 ## How to Get a Workflow File
 

--- a/workflows/ltx2_bridge_api.json
+++ b/workflows/ltx2_bridge_api.json
@@ -1,0 +1,112 @@
+{
+  "_bridge": {
+    "version": 1,
+    "name": "LTX-2 T2V Bridge",
+    "media_type": "video",
+    "supports_negative": true,
+    "nodes": {
+      "prompt": "3",
+      "negative_prompt": "4",
+      "sampler": "7",
+      "latent": null,
+      "video_latent": "6",
+      "output": "10",
+      "source_image": null
+    },
+    "fields": {
+      "prompt": "text",
+      "negative_prompt": "text",
+      "seed": "seed",
+      "width": "width",
+      "height": "height",
+      "steps": "steps",
+      "cfg": "cfg",
+      "length": "length"
+    }
+  },
+  "1": {
+    "inputs": {
+      "ckpt_name": "ltx-2-19b-distilled-fp8.safetensors"
+    },
+    "class_type": "CheckpointLoaderSimple"
+  },
+  "2": {
+    "inputs": {
+      "clip_name1": "clip_l.safetensors",
+      "clip_name2": "t5xxl_fp16.safetensors",
+      "type": "ltxv"
+    },
+    "class_type": "DualCLIPLoader"
+  },
+  "3": {
+    "inputs": {
+      "text": "A cinematic shot of a person walking through a futuristic city with neon lights",
+      "clip": ["2", 0]
+    },
+    "class_type": "CLIPTextEncode"
+  },
+  "4": {
+    "inputs": {
+      "text": "",
+      "clip": ["2", 0]
+    },
+    "class_type": "CLIPTextEncode"
+  },
+  "5": {
+    "inputs": {
+      "positive": ["3", 0],
+      "negative": ["4", 0],
+      "frame_rate": 24.0
+    },
+    "class_type": "LTXVConditioning"
+  },
+  "6": {
+    "inputs": {
+      "width": 768,
+      "height": 512,
+      "length": 97,
+      "batch_size": 1
+    },
+    "class_type": "EmptyLTXVLatentVideo"
+  },
+  "7": {
+    "inputs": {
+      "seed": 42,
+      "steps": 20,
+      "cfg": 3.0,
+      "sampler_name": "euler",
+      "scheduler": "simple",
+      "denoise": 1.0,
+      "model": ["1", 0],
+      "positive": ["5", 0],
+      "negative": ["5", 1],
+      "latent_image": ["6", 0]
+    },
+    "class_type": "KSampler"
+  },
+  "8": {
+    "inputs": {
+      "samples": ["7", 0],
+      "vae": ["1", 2]
+    },
+    "class_type": "VAEDecode"
+  },
+  "9": {
+    "inputs": {
+      "filename_prefix": "LTX2_bridge_frames",
+      "images": ["8", 0]
+    },
+    "class_type": "SaveImage"
+  },
+  "10": {
+    "inputs": {
+      "filename_prefix": "video/aipg",
+      "images": ["8", 0],
+      "frame_rate": 24,
+      "format": "video/h264-mp4",
+      "pingpong": false,
+      "save_output": true
+    },
+    "class_type": "VHS_VideoCombine"
+  }
+}


### PR DESCRIPTION
- Update .env.example to include optional settings for video workflows and worker types.
- Modify model_mapper.py to map LTX-2 model names for video processing.
- Revise README.md to clarify support for video jobs and provide setup instructions for LTX-2 workers.
- Add command line arguments in start_bridge.py for video workflows and worker types.
- Update workflows/README.md to document the new ltx2_bridge_api.json workflow for LTX-2.